### PR TITLE
Enable Cache Busting for /status.json

### DIFF
--- a/web/index.js
+++ b/web/index.js
@@ -459,7 +459,7 @@
 	};
 
 	$(function init() {
-		$.getJSON('./status.json')
+		$.getJSON('./status.json', {_: new Date().getTime()})
 			.then(render)
 			.then(pollJSON)
 			.fail(handleError);
@@ -470,7 +470,7 @@
 	}
 
 	function update() {
-		$.getJSON('./status.json')
+		$.getJSON('./status.json', {_: new Date().getTime()})
 			.then(setPollInterval)
 			.then(render)
 			.fail(handleError);


### PR DESCRIPTION
I'm running some Load-Balancers in front of PiAware which occasionally reports services (Radio, PiAware, MLAT, GPS, ...) to be down as data is cached and possibly outdated.